### PR TITLE
Use Node.js subpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: bun install
       - run: bun run build
+      - run: mv dist/* .
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Quinn Turner
+Copyright (c) 2024 Quinn Turner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owasp",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "publishConfig": {
@@ -15,21 +15,29 @@
   },
   "keywords": ["owasp", "logging", "security"],
   "exports": {
-    ".": {
+    "./dom": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dom/index.d.ts",
+        "default": "./dom/index.js"
       },
       "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
+        "types": "./dom/index.d.cts",
+        "default": "./dom/index.cjs"
+      }
+    },
+    "./vocab": {
+      "import": {
+        "types": "./vocab/index.d.ts",
+        "default": "./vocab/index.js"
+      },
+      "require": {
+        "types": "./vocab/index.d.cts",
+        "default": "./vocab/index.cjs"
       }
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.cjs",
-  "types": "./dist/index.d.cts",
-  "files": ["dist"],
+  "files": ["dom", "vocab"],
   "scripts": {
     "format": "biome format ./src --write",
     "lint": "biome lint ./src",

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,0 +1,1 @@
+export * from "./dom/index.js";

--- a/src/vocab.ts
+++ b/src/vocab.ts
@@ -1,2 +1,1 @@
-export * from "./dom/index.js";
 export * from "./vocab/index.js";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
+	entry: ["src/dom/index.ts", "src/vocab/index.ts"],
 	splitting: false,
 	sourcemap: true,
 	format: ["cjs", "esm"],


### PR DESCRIPTION
By hoisting the dist directory, we can now import the vocab using
import { authn_login_fail } from 'owasp/vocab';
